### PR TITLE
Add gdisk as dependency, readd image ignorance and isohybrid parameters

### DIFF
--- a/README
+++ b/README
@@ -13,6 +13,7 @@ Dependencies:
   xorriso
   python-fll
   squashfs-tools
+  gdisk
   isolinux
   syslinux
   syslinux-utils

--- a/debian/control
+++ b/debian/control
@@ -17,6 +17,7 @@ Vcs-Browser: https://github.com/fullstory/pyfll
 #         python-apt,
 #         python-configobj,
 #         debootstrap | cdebootstrap,
+#         gdisk,
 #         isolinux,
 #         xorriso,
 #         reprepro,

--- a/pyfll
+++ b/pyfll
@@ -1696,7 +1696,7 @@ class FLLBuilder(object):
 
         exclude_file = os.path.join(self.opts.s, 'data', 'fll_sqfs_exclusion')
         shutil.copy(exclude_file, os.path.join(chroot, 'tmp'))
-        cmd.extend(['-wildcards', '-ef', '/tmp/fll_sqfs_exclusion'])
+        cmd.extend(['-wildcards', '-ef', '/tmp/fll_sqfs_exclusion', '-e', image_file])
 
         # set compression algorithm for squashfs-tools >= 4.1
         squashfs_comp = self.conf['options'].get('squashfs_comp')
@@ -2415,7 +2415,9 @@ class FLLBuilder(object):
         if os.path.isfile(os.path.join(stage, 'boot/isolinux/isolinux.bin')):
             cmd += ' -no-emul-boot -boot-load-size 4 -boot-info-table'
             cmd += ' -b boot/isolinux/isolinux.bin -c boot/isolinux/isolinux.cat'
-            cmd2 = 'isohybrid -h 255 -s 63 %s' % iso_file
+            ''' iso don't work with vbox - so using the old code might be a better idea'''
+            '''cmd2 = 'isohybrid -h 255 -s 63 %s' % iso_file'''
+            cmd2 = 'isohybrid %s' % iso_file
 
         elif os.path.isdir(os.path.join(stage, 'boot/grub')):
             cmd += ' -no-emul-boot -boot-load-size 4 -boot-info-table'


### PR DESCRIPTION
* gpthybrid needs gdisk, added to debian/control and README
* readded the -e image_file to mksquash, lost in commit 1608041
  "remove support for dmsetup based rootfs."
* revert 3b607af0 "isohybrid: adapt geometry for ISOs larger than 1 GB." as
  virtualbox don't recognize the iso with the new settings